### PR TITLE
Support \VCR\VCR::configure()->setStorage

### DIFF
--- a/PHPUnit/Util/Log/VCR.php
+++ b/PHPUnit/Util/Log/VCR.php
@@ -125,8 +125,6 @@ class PHPUnit_Util_Log_VCR implements PHPUnit_Framework_TestListener
         // If the cassette name ends in .json, then use the JSON storage format
         if (substr($cassetteName, '-5') == '.json') {
             \VCR\VCR::configure()->setStorage('json');
-        } else {
-            \VCR\VCR::configure()->setStorage('yaml');
         }
 
         if (empty($cassetteName)) {


### PR DESCRIPTION
Allow VCR configuration to be used, instead of forcing a fallback to YAML cassette storage.

This could probably be further enhanced by also checking for `.yaml` extension. If that's wanted, I can add it in.

Moving forwards, there should probably be some way for this package to read what the registered storage types are (JSON, YAML, Blackhole, something custom), and dynamically set that if an appropriate extension is detected.

Fixes #9